### PR TITLE
only validate resource found from the READ test

### DIFF
--- a/generator/saner/profile_validation_test.rb
+++ b/generator/saner/profile_validation_test.rb
@@ -6,13 +6,15 @@ module Inferno
       def create_profile_validation_test(sequence)
         test_key = :validate_resources
         search_test = {
-          tests_that: "#{sequence[:resource]} resources returned from previous search conform to the #{sequence[:profile_name]}.",
+          tests_that: "The #{sequence[:resource]} resource returned from the first Read test is valid according to the profile #{sequence[:profile]}.",
           key: test_key,
           index: sequence[:tests].length + 1,
           description: %()
         }
         search_test[:test_code] = %(
-          test_resources_against_profile('#{sequence[:resource]}', '#{sequence[:profile]}')
+          skip 'No resource found from Read test' unless @resource_found.present?
+
+          test_resource_against_profile('#{sequence[:resource]}', @resource_found, '#{sequence[:profile]}')
         )
         sequence[:tests] << search_test
       end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -675,6 +675,22 @@ module Inferno
         assert(errors.empty?, errors.join("<br/>\n"))
       end
 
+      def test_resource_against_profile(resource_type, resource, specified_profile)
+        @profiles_encountered ||= Set.new
+        @profiles_failed ||= Hash.new { |hash, key| hash[key] = [] }
+        return test_resources(resource_type) if specified_profile.blank?
+
+        profile = Inferno::ValidationUtil::DEFINITIONS[specified_profile]
+        skip_if(
+          profile.blank?,
+          "Skip profile validation since profile #{specified_profile} is unknown."
+        )
+
+        error = validate_resource(resource_type, resource, profile)
+
+        assert(error.blank?, error)
+      end
+
       def test_resources_against_profile(resource_type, specified_profile = nil, &block)
         @profiles_encountered ||= Set.new
         @profiles_failed ||= Hash.new { |hash, key| hash[key] = [] }

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasure_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasure_sequence.rb
@@ -149,7 +149,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '05'
-          name 'Measure resources returned from previous search conform to the Saner Public Health Measure.'
+          name 'The Measure resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure.'
           link ''
           description %(
 
@@ -157,7 +157,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('Measure', 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
       end
     end
   end

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasurereport_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasurereport_sequence.rb
@@ -285,7 +285,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '09'
-          name 'MeasureReport resources returned from previous search conform to the Saner Public Health Measure Report.'
+          name 'The MeasureReport resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport.'
           link ''
           description %(
 
@@ -293,7 +293,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('MeasureReport', 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('MeasureReport', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
       end
     end
   end

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasurestratifier_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasurestratifier_sequence.rb
@@ -149,7 +149,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '05'
-          name 'Measure resources returned from previous search conform to the Saner Public Health Measure Stratifier.'
+          name 'The Measure resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier.'
           link ''
           description %(
 
@@ -157,7 +157,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('Measure', 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
       end
     end
   end

--- a/lib/modules/saner/MeasureConsumerPull/saner_resource_location_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/saner_resource_location_sequence.rb
@@ -395,7 +395,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '12'
-          name 'Location resources returned from previous search conform to the Resource Location Profile.'
+          name 'The Location resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location.'
           link ''
           description %(
 
@@ -403,7 +403,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('Location', 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('Location', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasure_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasure_sequence.rb
@@ -149,7 +149,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '05'
-          name 'Measure resources returned from previous search conform to the Saner Public Health Measure.'
+          name 'The Measure resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure.'
           link ''
           description %(
 
@@ -157,7 +157,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('Measure', 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasurereport_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasurereport_sequence.rb
@@ -285,7 +285,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '09'
-          name 'MeasureReport resources returned from previous search conform to the Saner Public Health Measure Report.'
+          name 'The MeasureReport resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport.'
           link ''
           description %(
 
@@ -293,7 +293,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('MeasureReport', 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('MeasureReport', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasurestratifier_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasurestratifier_sequence.rb
@@ -149,7 +149,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '05'
-          name 'Measure resources returned from previous search conform to the Saner Public Health Measure Stratifier.'
+          name 'The Measure resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier.'
           link ''
           description %(
 
@@ -157,7 +157,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('Measure', 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/saner_resource_location_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/saner_resource_location_sequence.rb
@@ -395,7 +395,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '12'
-          name 'Location resources returned from previous search conform to the Resource Location Profile.'
+          name 'The Location resource returned from the first Read test is valid according to the profile http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location.'
           link ''
           description %(
 
@@ -403,7 +403,9 @@ module Inferno
           versions :r4
         end
 
-        test_resources_against_profile('Location', 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
+        skip 'No resource found from Read test' unless @resource_found.present?
+
+        test_resource_against_profile('Location', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
       end
     end
   end


### PR DESCRIPTION
This makes it so we only validate the resource returned from the initial read test.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
