### PR TITLE
Maintain Primitive Extensions when Validating

### DIFF
--- a/generator/saner/profile_validation_test.rb
+++ b/generator/saner/profile_validation_test.rb
@@ -14,7 +14,7 @@ module Inferno
         search_test[:test_code] = %(
           skip 'No resource found from Read test' unless @resource_found.present?
 
-          test_resource_against_profile('#{sequence[:resource]}', @resource_found, '#{sequence[:profile]}')
+          test_resource_against_profile('#{sequence[:resource]}', @raw_resource_found, '#{sequence[:profile]}')
         )
         sequence[:tests] << search_test
       end

--- a/generator/saner/read_test.rb
+++ b/generator/saner/read_test.rb
@@ -14,8 +14,10 @@ module Inferno
         }
         read_test[:test_code] = %(
             resource_id = @instance.#{sequence[:resource].downcase}_id
-            @resource_found = validate_read_reply(FHIR::#{sequence[:resource]}.new(id: resource_id), FHIR::#{sequence[:resource]})
-          )
+            read_response = validate_read_reply(FHIR::#{sequence[:resource]}.new(id: resource_id), FHIR::#{sequence[:resource]})
+            @resource_found = read_response.resource
+            @raw_resource_found = read_response.response[:body]
+        )
         sequence[:tests] << read_test
       end
     end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -542,20 +542,19 @@ module Inferno
       def validate_read_reply(resource, klass, reply_handler = nil)
         class_name = klass.name.demodulize
         assert !resource.nil?, "No #{class_name} resources available from search."
-        if resource.is_a? versioned_resource_class('Reference')
-          read_response = resource.read
-          id = resource.reference.split('/').last
-        else
-          id = resource&.id
-          assert !id.nil?, "#{class_name} id not returned"
-          read_response = @client.read(klass, id)
-          assert_response_ok read_response
-          reply_handler&.call(read_response)
-          read_response = read_response.resource
-        end
-        assert !read_response.nil?, "Expected #{class_name} resource to be present."
-        assert read_response.is_a?(klass), "Expected resource to be of type #{class_name}."
-        assert read_response.id.present? && read_response.id == id, "Expected resource to contain id: #{id}"
+        id = if resource.is_a? versioned_resource_class('Reference')
+               resource.reference.split('/').last
+             else
+               resource&.id
+             end
+        assert !id.nil?, "#{class_name} id not returned"
+        read_response = @client.read(klass, id)
+        assert_response_ok read_response
+        reply_handler&.call(read_response)
+        read_resource = read_response.resource
+        assert !read_resource.nil?, "Expected #{class_name} resource to be present."
+        assert read_resource.is_a?(klass), "Expected resource to be of type #{class_name}."
+        assert read_resource.id.present? && read_resource.id == id, "Expected resource to contain id: #{id}"
         read_response
       end
 

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -622,7 +622,7 @@ module Inferno
         @test_warnings.concat resource_validation_errors[:warnings]
         @information_messages.concat resource_validation_errors[:information]
 
-        errors.map! { |e| "#{resource_type}/#{resource.id}: #{e}" }
+        errors.map! { |e| "#{resource_type}/#{JSON.parse(resource)['id']}: #{e}" }
         @profiles_failed[profile.url].concat(errors) unless errors.empty?
         errors
       end

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module Inferno
   # A validator that calls out to the HL7 validator API
   class HL7Validator
@@ -12,25 +14,36 @@ module Inferno
     end
 
     def validate(resource, fhir_models_klass, profile_url = nil)
-      profile_url ||= fhir_models_klass::Definitions.resource_definition(resource.resourceType).url
+      if resource.is_a? String
+        profile_url ||= fhir_models_klass::Definitions.resource_definition(JSON.parse(resource)['resourceType']).url
+        validate_json_against_profile(resource, fhir_models_klass, profile_url)
+      else
+        profile_url ||= fhir_models_klass::Definitions.resource_definition(resource.resourceType).url
 
-      Inferno.logger.info("Validating #{resource.resourceType} resource with id #{resource.id}")
-      Inferno.logger.info("POST #{@validator_url}/validate?profile=#{profile_url}")
+        Inferno.logger.info("Validating #{resource.resourceType} resource with id #{resource.id}")
+        Inferno.logger.info("POST #{@validator_url}/validate?profile=#{profile_url}")
 
-      result = RestClient.post "#{@validator_url}/validate", resource.to_json, params: { profile: profile_url }
+        validate_json_against_profile(resource.to_json, fhir_models_klass, profile_url)
+      end
+    end
+
+
+
+    private
+
+    def validate_json_against_profile(resource, fhir_models_klass, profile)
+      result = RestClient.post "#{@validator_url}/validate", resource, params: { profile: profile }
       outcome = fhir_models_klass.from_contents(result.body)
       fatals = issues_by_severity(outcome.issue, 'fatal')
       errors = issues_by_severity(outcome.issue, 'error')
       warnings = issues_by_severity(outcome.issue, 'warning')
       information = issues_by_severity(outcome.issue, 'information')
       {
-        errors: fatals.concat(errors).reject(&:empty?),
-        warnings: warnings,
-        information: information
+          errors: fatals.concat(errors).reject(&:empty?),
+          warnings: warnings,
+          information: information
       }
     end
-
-    private
 
     def issues_by_severity(issues, severity)
       issues.select { |i| i.severity == severity }

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -27,8 +27,6 @@ module Inferno
       end
     end
 
-
-
     private
 
     def validate_json_against_profile(resource, fhir_models_klass, profile)
@@ -39,9 +37,9 @@ module Inferno
       warnings = issues_by_severity(outcome.issue, 'warning')
       information = issues_by_severity(outcome.issue, 'information')
       {
-          errors: fatals.concat(errors).reject(&:empty?),
-          warnings: warnings,
-          information: information
+        errors: fatals.concat(errors).reject(&:empty?),
+        warnings: warnings,
+        information: information
       }
     end
 

--- a/lib/modules/argonaut/argonaut_medication_order_sequence.rb
+++ b/lib/modules/argonaut/argonaut_medication_order_sequence.rb
@@ -113,7 +113,7 @@ module Inferno
         skip 'No resources appear to be available for this patient. Please use patients with more information.' unless @resources_found
 
         @medication_orders.each do |medication_order|
-          validate_read_reply(medication_order, versioned_resource_class('MedicationOrder'))
+          validate_read_reply(medication_order, versioned_resource_class('MedicationOrder')).resource
         end
       end
 
@@ -189,7 +189,7 @@ module Inferno
         pass 'Test passes because all medication resource references are contained within the medication orders.' if not_contained_refs.empty?
 
         not_contained_refs&.each do |medication|
-          validate_read_reply(medication, versioned_resource_class('Medication'))
+          validate_read_reply(medication, versioned_resource_class('Medication')).resource
         end
       end
 

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasure_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasure_sequence.rb
@@ -53,7 +53,9 @@ module Inferno
         end
 
         resource_id = @instance.measure_id
-        @resource_found = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        read_response = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by_url do
@@ -159,7 +161,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
+        test_resource_against_profile('Measure', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
       end
     end
   end

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasurereport_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasurereport_sequence.rb
@@ -75,7 +75,9 @@ module Inferno
         end
 
         resource_id = @instance.measurereport_id
-        @resource_found = validate_read_reply(FHIR::MeasureReport.new(id: resource_id), FHIR::MeasureReport)
+        read_response = validate_read_reply(FHIR::MeasureReport.new(id: resource_id), FHIR::MeasureReport)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by__id do
@@ -295,7 +297,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('MeasureReport', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
+        test_resource_against_profile('MeasureReport', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
       end
     end
   end

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasurestratifier_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasurestratifier_sequence.rb
@@ -53,7 +53,9 @@ module Inferno
         end
 
         resource_id = @instance.measure_id
-        @resource_found = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        read_response = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by_url do
@@ -159,7 +161,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
+        test_resource_against_profile('Measure', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
       end
     end
   end

--- a/lib/modules/saner/MeasureConsumerPull/saner_resource_location_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/saner_resource_location_sequence.rb
@@ -99,7 +99,9 @@ module Inferno
         end
 
         resource_id = @instance.location_id
-        @resource_found = validate_read_reply(FHIR::Location.new(id: resource_id), FHIR::Location)
+        read_response = validate_read_reply(FHIR::Location.new(id: resource_id), FHIR::Location)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by__id do
@@ -405,7 +407,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('Location', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
+        test_resource_against_profile('Location', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasure_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasure_sequence.rb
@@ -53,7 +53,9 @@ module Inferno
         end
 
         resource_id = @instance.measure_id
-        @resource_found = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        read_response = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by_url do
@@ -159,7 +161,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
+        test_resource_against_profile('Measure', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasure')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasurereport_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasurereport_sequence.rb
@@ -75,7 +75,9 @@ module Inferno
         end
 
         resource_id = @instance.measurereport_id
-        @resource_found = validate_read_reply(FHIR::MeasureReport.new(id: resource_id), FHIR::MeasureReport)
+        read_response = validate_read_reply(FHIR::MeasureReport.new(id: resource_id), FHIR::MeasureReport)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by__id do
@@ -295,7 +297,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('MeasureReport', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
+        test_resource_against_profile('MeasureReport', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureReport')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasurestratifier_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasurestratifier_sequence.rb
@@ -53,7 +53,9 @@ module Inferno
         end
 
         resource_id = @instance.measure_id
-        @resource_found = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        read_response = validate_read_reply(FHIR::Measure.new(id: resource_id), FHIR::Measure)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by_url do
@@ -159,7 +161,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('Measure', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
+        test_resource_against_profile('Measure', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/PublicHealthMeasureStratifier')
       end
     end
   end

--- a/lib/modules/saner/MeasureSourcePull/saner_resource_location_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/saner_resource_location_sequence.rb
@@ -99,7 +99,9 @@ module Inferno
         end
 
         resource_id = @instance.location_id
-        @resource_found = validate_read_reply(FHIR::Location.new(id: resource_id), FHIR::Location)
+        read_response = validate_read_reply(FHIR::Location.new(id: resource_id), FHIR::Location)
+        @resource_found = read_response.resource
+        @raw_resource_found = read_response.response[:body]
       end
 
       test :search_by__id do
@@ -405,7 +407,7 @@ module Inferno
 
         skip 'No resource found from Read test' unless @resource_found.present?
 
-        test_resource_against_profile('Location', @resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
+        test_resource_against_profile('Location', @raw_resource_found, 'http://hl7.org/fhir/us/saner/StructureDefinition/saner-resource-location')
       end
     end
   end


### PR DESCRIPTION
Inferno was stripping out primitive extensions when validating, which was giving validation errors.

This fixes this by saving the raw_returned resource for validating.