### PR TITLE
use multiple expressions to evaluate search param

### DIFF
--- a/generator/capability_statement_parser.rb
+++ b/generator/capability_statement_parser.rb
@@ -341,11 +341,13 @@ module Inferno
           path = path.gsub(/.where\((.*)/, '')
           as_type = path.scan(/.as\((.*?)\)/).flatten.first
           path = path.gsub(/.as\((.*?)\)/, capitalize_first_letter(as_type)) if as_type.present?
+          expression = search_param_definition['expression'].split('|').map(&:strip).select { |expression| [sequence[:resource], 'Resource'].include? expression.split('.').first }
           profile_element = profile_definition['snapshot']['element'].select { |el| el['id'] == path }.first
           param_metadata = {
             path: path,
             comparators: {},
-            values: Set.new
+            values: Set.new,
+            expression: expression
           }
           if !profile_element.nil?
             param_metadata[:type] = profile_element['type'].first['code']

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -813,7 +813,28 @@ module Inferno
         end.compact
       end
 
+      def resolve_path_comma_delimited(elements, paths)
+        results_found = []
+        paths.split(',').each do |path|
+          results_found += resolve_path(elements, path)
+        end
+        results_found
+      end
+
+      def resolve_element_from_paths_comma_delimited(element, paths)
+        paths.split(',').each do |path|
+          el_found = if block_given?
+                       resolve_element_from_path(element, path)  { |value_found| yield(value_found) }
+                     else
+                       resolve_element_from_path(element, path)
+                     end
+          return el_found if el_found.present?
+        end
+        nil
+      end
+
       def resolve_element_from_path(element, path)
+        binding.pry if path.include? ','
         el_as_array = Array.wrap(element)
         if path.empty?
           return nil if element.nil?

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasure_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasure_sequence.rb
@@ -19,19 +19,19 @@ module Inferno
         case property
 
         when 'url'
-          values_found = resolve_path(resource, 'url')
+          values_found = resolve_path_comma_delimited(resource, 'url')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "url in Measure/#{resource.id} (#{values_found}) does not match url requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'topic.coding.code')
+          values_found = resolve_path_comma_delimited(resource, 'topic.coding.code,group.code.coding.code,group.population.code.coding.code,group.stratifier.code.coding.code,group.stratifier.component.code.coding.code,supplementalData.code.coding.code')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "code in Measure/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'definition-text'
-          values_found = resolve_path(resource, 'title')
+          values_found = resolve_path_comma_delimited(resource, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "definition-text in Measure/#{resource.id} (#{values_found}) does not match definition-text requested (#{value})"
@@ -73,9 +73,11 @@ module Inferno
           versions :r4
         end
 
+        url_value = resolve_element_from_paths_comma_delimited(@resource_found, 'url') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'url': get_value_for_search_param(resolve_element_from_path(@resource_found, 'url') { |el| get_value_for_search_param(el).present? })
+          'url': get_value_for_search_param(url_value)
         }
+
         skip 'Could not find parameter value for ["url"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -103,9 +105,11 @@ module Inferno
           versions :r4
         end
 
+        code_value = resolve_element_from_paths_comma_delimited(@resource_found, 'topic,group.code,group.population.code,group.stratifier.code,group.stratifier.component.code,supplementalData.code') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'code': get_value_for_search_param(resolve_element_from_path(@resource_found, 'topic') { |el| get_value_for_search_param(el).present? })
+          'code': get_value_for_search_param(code_value)
         }
+
         skip 'Could not find parameter value for ["code"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -133,9 +137,11 @@ module Inferno
           versions :r4
         end
 
+        definition_text_value = resolve_element_from_paths_comma_delimited(@resource_found, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'definition-text': get_value_for_search_param(resolve_element_from_path(@resource_found, 'title') { |el| get_value_for_search_param(el).present? })
+          'definition-text': get_value_for_search_param(definition_text_value)
         }
+
         skip 'Could not find parameter value for ["definition-text"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasurereport_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasurereport_sequence.rb
@@ -19,41 +19,41 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path_comma_delimited(resource, 'id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in MeasureReport/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'group.code.coding.code')
+          values_found = resolve_path_comma_delimited(resource, 'group.code.coding.code,group.population.code.coding.code,group.stratifier.code.coding.code,group.stratifier.stratum.component.code.coding.code,group.stratifier.stratum.population.code.coding.code')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "code in MeasureReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'date')
+          values_found = resolve_path_comma_delimited(resource, 'date')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "date in MeasureReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'measure'
-          values_found = resolve_path(resource, 'measure')
+          values_found = resolve_path_comma_delimited(resource, 'measure')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "measure in MeasureReport/#{resource.id} (#{values_found}) does not match measure requested (#{value})"
 
         when 'subject'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path_comma_delimited(resource, 'subject.reference')
           match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
           assert match_found, "subject in MeasureReport/#{resource.id} (#{values_found}) does not match subject requested (#{value})"
 
         when 'period'
-          values_found = resolve_path(resource, 'period')
+          values_found = resolve_path_comma_delimited(resource, 'period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "period in MeasureReport/#{resource.id} (#{values_found}) does not match period requested (#{value})"
 
         when 'reporter'
-          values_found = resolve_path(resource, 'reporter.reference')
+          values_found = resolve_path_comma_delimited(resource, 'reporter.reference')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "reporter in MeasureReport/#{resource.id} (#{values_found}) does not match reporter requested (#{value})"
@@ -94,9 +94,11 @@ module Inferno
           versions :r4
         end
 
+        _id_value = resolve_element_from_paths_comma_delimited(@resource_found, 'id') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          '_id': get_value_for_search_param(resolve_element_from_path(@resource_found, 'id') { |el| get_value_for_search_param(el).present? })
+          '_id': get_value_for_search_param(_id_value)
         }
+
         skip 'Could not find parameter value for ["_id"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -123,9 +125,11 @@ module Inferno
           versions :r4
         end
 
+        date_value = resolve_element_from_paths_comma_delimited(@resource_found, 'date') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'date': get_value_for_search_param(resolve_element_from_path(@resource_found, 'date') { |el| get_value_for_search_param(el).present? })
+          'date': get_value_for_search_param(date_value)
         }
+
         skip 'Could not find parameter value for ["date"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -152,9 +156,11 @@ module Inferno
           versions :r4
         end
 
+        measure_value = resolve_element_from_paths_comma_delimited(@resource_found, 'measure') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'measure': get_value_for_search_param(resolve_element_from_path(@resource_found, 'measure') { |el| get_value_for_search_param(el).present? })
+          'measure': get_value_for_search_param(measure_value)
         }
+
         skip 'Could not find parameter value for ["measure"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -181,9 +187,11 @@ module Inferno
           versions :r4
         end
 
+        subject_value = resolve_element_from_paths_comma_delimited(@resource_found, 'subject') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'subject': get_value_for_search_param(resolve_element_from_path(@resource_found, 'subject') { |el| get_value_for_search_param(el).present? })
+          'subject': get_value_for_search_param(subject_value)
         }
+
         skip 'Could not find parameter value for ["subject"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -210,9 +218,11 @@ module Inferno
           versions :r4
         end
 
+        period_value = resolve_element_from_paths_comma_delimited(@resource_found, 'period') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'period': get_value_for_search_param(resolve_element_from_path(@resource_found, 'period') { |el| get_value_for_search_param(el).present? })
+          'period': get_value_for_search_param(period_value)
         }
+
         skip 'Could not find parameter value for ["period"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -239,9 +249,11 @@ module Inferno
           versions :r4
         end
 
+        reporter_value = resolve_element_from_paths_comma_delimited(@resource_found, 'reporter') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'reporter': get_value_for_search_param(resolve_element_from_path(@resource_found, 'reporter') { |el| get_value_for_search_param(el).present? })
+          'reporter': get_value_for_search_param(reporter_value)
         }
+
         skip 'Could not find parameter value for ["reporter"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -269,9 +281,11 @@ module Inferno
           versions :r4
         end
 
+        code_value = resolve_element_from_paths_comma_delimited(@resource_found, 'group.code,group.population.code,group.stratifier.code,group.stratifier.stratum.component.code,group.stratifier.stratum.population.code') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'code': get_value_for_search_param(resolve_element_from_path(@resource_found, 'group.code') { |el| get_value_for_search_param(el).present? })
+          'code': get_value_for_search_param(code_value)
         }
+
         skip 'Could not find parameter value for ["code"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)

--- a/lib/modules/saner/MeasureConsumerPull/publichealthmeasurestratifier_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/publichealthmeasurestratifier_sequence.rb
@@ -19,19 +19,19 @@ module Inferno
         case property
 
         when 'url'
-          values_found = resolve_path(resource, 'url')
+          values_found = resolve_path_comma_delimited(resource, 'url')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "url in Measure/#{resource.id} (#{values_found}) does not match url requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'topic.coding.code')
+          values_found = resolve_path_comma_delimited(resource, 'topic.coding.code,group.code.coding.code,group.population.code.coding.code,group.stratifier.code.coding.code,group.stratifier.component.code.coding.code,supplementalData.code.coding.code')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "code in Measure/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'definition-text'
-          values_found = resolve_path(resource, 'title')
+          values_found = resolve_path_comma_delimited(resource, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "definition-text in Measure/#{resource.id} (#{values_found}) does not match definition-text requested (#{value})"
@@ -73,9 +73,11 @@ module Inferno
           versions :r4
         end
 
+        url_value = resolve_element_from_paths_comma_delimited(@resource_found, 'url') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'url': get_value_for_search_param(resolve_element_from_path(@resource_found, 'url') { |el| get_value_for_search_param(el).present? })
+          'url': get_value_for_search_param(url_value)
         }
+
         skip 'Could not find parameter value for ["url"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -103,9 +105,11 @@ module Inferno
           versions :r4
         end
 
+        code_value = resolve_element_from_paths_comma_delimited(@resource_found, 'topic,group.code,group.population.code,group.stratifier.code,group.stratifier.component.code,supplementalData.code') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'code': get_value_for_search_param(resolve_element_from_path(@resource_found, 'topic') { |el| get_value_for_search_param(el).present? })
+          'code': get_value_for_search_param(code_value)
         }
+
         skip 'Could not find parameter value for ["code"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -133,9 +137,11 @@ module Inferno
           versions :r4
         end
 
+        definition_text_value = resolve_element_from_paths_comma_delimited(@resource_found, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'definition-text': get_value_for_search_param(resolve_element_from_path(@resource_found, 'title') { |el| get_value_for_search_param(el).present? })
+          'definition-text': get_value_for_search_param(definition_text_value)
         }
+
         skip 'Could not find parameter value for ["definition-text"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)

--- a/lib/modules/saner/MeasureConsumerPull/saner_resource_location_sequence.rb
+++ b/lib/modules/saner/MeasureConsumerPull/saner_resource_location_sequence.rb
@@ -19,30 +19,30 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path_comma_delimited(resource, 'id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in Location/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when '_lastUpdated'
-          values_found = resolve_path(resource, 'meta.lastUpdated')
+          values_found = resolve_path_comma_delimited(resource, 'meta.lastUpdated')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "_lastUpdated in Location/#{resource.id} (#{values_found}) does not match _lastUpdated requested (#{value})"
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path_comma_delimited(resource, 'name,alias')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier.value')
+          values_found = resolve_path_comma_delimited(resource, 'identifier.value')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "identifier in Location/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'address'
-          values_found = resolve_path(resource, 'address')
+          values_found = resolve_path_comma_delimited(resource, 'address')
           match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
@@ -53,31 +53,31 @@ module Inferno
           assert match_found, "address in Location/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         when 'address-city'
-          values_found = resolve_path(resource, 'address.city')
+          values_found = resolve_path_comma_delimited(resource, 'address.city')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-country'
-          values_found = resolve_path(resource, 'address.country')
+          values_found = resolve_path_comma_delimited(resource, 'address.country')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-country in Location/#{resource.id} (#{values_found}) does not match address-country requested (#{value})"
 
         when 'address-postalcode'
-          values_found = resolve_path(resource, 'address.postalCode')
+          values_found = resolve_path_comma_delimited(resource, 'address.postalCode')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
 
         when 'address-state'
-          values_found = resolve_path(resource, 'address.state')
+          values_found = resolve_path_comma_delimited(resource, 'address.state')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-use'
-          values_found = resolve_path(resource, 'address.use')
+          values_found = resolve_path_comma_delimited(resource, 'address.use')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-use in Location/#{resource.id} (#{values_found}) does not match address-use requested (#{value})"
@@ -118,9 +118,11 @@ module Inferno
           versions :r4
         end
 
+        _id_value = resolve_element_from_paths_comma_delimited(@resource_found, 'id') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          '_id': get_value_for_search_param(resolve_element_from_path(@resource_found, 'id') { |el| get_value_for_search_param(el).present? })
+          '_id': get_value_for_search_param(_id_value)
         }
+
         skip 'Could not find parameter value for ["_id"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -147,9 +149,11 @@ module Inferno
           versions :r4
         end
 
+        _lastUpdated_value = resolve_element_from_paths_comma_delimited(@resource_found, 'meta.lastUpdated') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          '_lastUpdated': get_value_for_search_param(resolve_element_from_path(@resource_found, 'meta.lastUpdated') { |el| get_value_for_search_param(el).present? })
+          '_lastUpdated': get_value_for_search_param(_lastUpdated_value)
         }
+
         skip 'Could not find parameter value for ["_lastUpdated"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -176,9 +180,11 @@ module Inferno
           versions :r4
         end
 
+        name_value = resolve_element_from_paths_comma_delimited(@resource_found, 'name,alias') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'name': get_value_for_search_param(resolve_element_from_path(@resource_found, 'name') { |el| get_value_for_search_param(el).present? })
+          'name': get_value_for_search_param(name_value)
         }
+
         skip 'Could not find parameter value for ["name"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -205,9 +211,11 @@ module Inferno
           versions :r4
         end
 
+        identifier_value = resolve_element_from_paths_comma_delimited(@resource_found, 'identifier') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'identifier': get_value_for_search_param(resolve_element_from_path(@resource_found, 'identifier') { |el| get_value_for_search_param(el).present? })
+          'identifier': get_value_for_search_param(identifier_value)
         }
+
         skip 'Could not find parameter value for ["identifier"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -234,9 +242,11 @@ module Inferno
           versions :r4
         end
 
+        address_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address') { |el| get_value_for_search_param(el).present? })
+          'address': get_value_for_search_param(address_value)
         }
+
         skip 'Could not find parameter value for ["address"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -263,9 +273,11 @@ module Inferno
           versions :r4
         end
 
+        address_city_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.city') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-city': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.city') { |el| get_value_for_search_param(el).present? })
+          'address-city': get_value_for_search_param(address_city_value)
         }
+
         skip 'Could not find parameter value for ["address-city"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -292,9 +304,11 @@ module Inferno
           versions :r4
         end
 
+        address_country_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.country') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-country': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.country') { |el| get_value_for_search_param(el).present? })
+          'address-country': get_value_for_search_param(address_country_value)
         }
+
         skip 'Could not find parameter value for ["address-country"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -321,9 +335,11 @@ module Inferno
           versions :r4
         end
 
+        address_postalcode_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.postalCode') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-postalcode': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.postalCode') { |el| get_value_for_search_param(el).present? })
+          'address-postalcode': get_value_for_search_param(address_postalcode_value)
         }
+
         skip 'Could not find parameter value for ["address-postalcode"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -350,9 +366,11 @@ module Inferno
           versions :r4
         end
 
+        address_state_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.state') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-state': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.state') { |el| get_value_for_search_param(el).present? })
+          'address-state': get_value_for_search_param(address_state_value)
         }
+
         skip 'Could not find parameter value for ["address-state"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -379,9 +397,11 @@ module Inferno
           versions :r4
         end
 
+        address_use_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.use') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-use': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.use') { |el| get_value_for_search_param(el).present? })
+          'address-use': get_value_for_search_param(address_use_value)
         }
+
         skip 'Could not find parameter value for ["address-use"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasure_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasure_sequence.rb
@@ -19,19 +19,19 @@ module Inferno
         case property
 
         when 'url'
-          values_found = resolve_path(resource, 'url')
+          values_found = resolve_path_comma_delimited(resource, 'url')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "url in Measure/#{resource.id} (#{values_found}) does not match url requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'topic.coding.code')
+          values_found = resolve_path_comma_delimited(resource, 'topic.coding.code,group.code.coding.code,group.population.code.coding.code,group.stratifier.code.coding.code,group.stratifier.component.code.coding.code,supplementalData.code.coding.code')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "code in Measure/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'definition-text'
-          values_found = resolve_path(resource, 'title')
+          values_found = resolve_path_comma_delimited(resource, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "definition-text in Measure/#{resource.id} (#{values_found}) does not match definition-text requested (#{value})"
@@ -73,9 +73,11 @@ module Inferno
           versions :r4
         end
 
+        url_value = resolve_element_from_paths_comma_delimited(@resource_found, 'url') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'url': get_value_for_search_param(resolve_element_from_path(@resource_found, 'url') { |el| get_value_for_search_param(el).present? })
+          'url': get_value_for_search_param(url_value)
         }
+
         skip 'Could not find parameter value for ["url"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -103,9 +105,11 @@ module Inferno
           versions :r4
         end
 
+        code_value = resolve_element_from_paths_comma_delimited(@resource_found, 'topic,group.code,group.population.code,group.stratifier.code,group.stratifier.component.code,supplementalData.code') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'code': get_value_for_search_param(resolve_element_from_path(@resource_found, 'topic') { |el| get_value_for_search_param(el).present? })
+          'code': get_value_for_search_param(code_value)
         }
+
         skip 'Could not find parameter value for ["code"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -133,9 +137,11 @@ module Inferno
           versions :r4
         end
 
+        definition_text_value = resolve_element_from_paths_comma_delimited(@resource_found, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'definition-text': get_value_for_search_param(resolve_element_from_path(@resource_found, 'title') { |el| get_value_for_search_param(el).present? })
+          'definition-text': get_value_for_search_param(definition_text_value)
         }
+
         skip 'Could not find parameter value for ["definition-text"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasurereport_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasurereport_sequence.rb
@@ -19,41 +19,41 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path_comma_delimited(resource, 'id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in MeasureReport/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'group.code.coding.code')
+          values_found = resolve_path_comma_delimited(resource, 'group.code.coding.code,group.population.code.coding.code,group.stratifier.code.coding.code,group.stratifier.stratum.component.code.coding.code,group.stratifier.stratum.population.code.coding.code')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "code in MeasureReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
-          values_found = resolve_path(resource, 'date')
+          values_found = resolve_path_comma_delimited(resource, 'date')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "date in MeasureReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'measure'
-          values_found = resolve_path(resource, 'measure')
+          values_found = resolve_path_comma_delimited(resource, 'measure')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "measure in MeasureReport/#{resource.id} (#{values_found}) does not match measure requested (#{value})"
 
         when 'subject'
-          values_found = resolve_path(resource, 'subject.reference')
+          values_found = resolve_path_comma_delimited(resource, 'subject.reference')
           match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
           assert match_found, "subject in MeasureReport/#{resource.id} (#{values_found}) does not match subject requested (#{value})"
 
         when 'period'
-          values_found = resolve_path(resource, 'period')
+          values_found = resolve_path_comma_delimited(resource, 'period')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "period in MeasureReport/#{resource.id} (#{values_found}) does not match period requested (#{value})"
 
         when 'reporter'
-          values_found = resolve_path(resource, 'reporter.reference')
+          values_found = resolve_path_comma_delimited(resource, 'reporter.reference')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "reporter in MeasureReport/#{resource.id} (#{values_found}) does not match reporter requested (#{value})"
@@ -94,9 +94,11 @@ module Inferno
           versions :r4
         end
 
+        _id_value = resolve_element_from_paths_comma_delimited(@resource_found, 'id') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          '_id': get_value_for_search_param(resolve_element_from_path(@resource_found, 'id') { |el| get_value_for_search_param(el).present? })
+          '_id': get_value_for_search_param(_id_value)
         }
+
         skip 'Could not find parameter value for ["_id"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -123,9 +125,11 @@ module Inferno
           versions :r4
         end
 
+        date_value = resolve_element_from_paths_comma_delimited(@resource_found, 'date') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'date': get_value_for_search_param(resolve_element_from_path(@resource_found, 'date') { |el| get_value_for_search_param(el).present? })
+          'date': get_value_for_search_param(date_value)
         }
+
         skip 'Could not find parameter value for ["date"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -152,9 +156,11 @@ module Inferno
           versions :r4
         end
 
+        measure_value = resolve_element_from_paths_comma_delimited(@resource_found, 'measure') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'measure': get_value_for_search_param(resolve_element_from_path(@resource_found, 'measure') { |el| get_value_for_search_param(el).present? })
+          'measure': get_value_for_search_param(measure_value)
         }
+
         skip 'Could not find parameter value for ["measure"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -181,9 +187,11 @@ module Inferno
           versions :r4
         end
 
+        subject_value = resolve_element_from_paths_comma_delimited(@resource_found, 'subject') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'subject': get_value_for_search_param(resolve_element_from_path(@resource_found, 'subject') { |el| get_value_for_search_param(el).present? })
+          'subject': get_value_for_search_param(subject_value)
         }
+
         skip 'Could not find parameter value for ["subject"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -210,9 +218,11 @@ module Inferno
           versions :r4
         end
 
+        period_value = resolve_element_from_paths_comma_delimited(@resource_found, 'period') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'period': get_value_for_search_param(resolve_element_from_path(@resource_found, 'period') { |el| get_value_for_search_param(el).present? })
+          'period': get_value_for_search_param(period_value)
         }
+
         skip 'Could not find parameter value for ["period"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -239,9 +249,11 @@ module Inferno
           versions :r4
         end
 
+        reporter_value = resolve_element_from_paths_comma_delimited(@resource_found, 'reporter') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'reporter': get_value_for_search_param(resolve_element_from_path(@resource_found, 'reporter') { |el| get_value_for_search_param(el).present? })
+          'reporter': get_value_for_search_param(reporter_value)
         }
+
         skip 'Could not find parameter value for ["reporter"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -269,9 +281,11 @@ module Inferno
           versions :r4
         end
 
+        code_value = resolve_element_from_paths_comma_delimited(@resource_found, 'group.code,group.population.code,group.stratifier.code,group.stratifier.stratum.component.code,group.stratifier.stratum.population.code') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'code': get_value_for_search_param(resolve_element_from_path(@resource_found, 'group.code') { |el| get_value_for_search_param(el).present? })
+          'code': get_value_for_search_param(code_value)
         }
+
         skip 'Could not find parameter value for ["code"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)
@@ -299,11 +313,15 @@ module Inferno
           versions :r4
         end
 
+        measure_value = resolve_element_from_paths_comma_delimited(@resource_found, 'measure') { |el| get_value_for_search_param(el).present? }
+        subject_value = resolve_element_from_paths_comma_delimited(@resource_found, 'subject') { |el| get_value_for_search_param(el).present? }
+        period_value = resolve_element_from_paths_comma_delimited(@resource_found, 'period') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'measure': get_value_for_search_param(resolve_element_from_path(@resource_found, 'measure') { |el| get_value_for_search_param(el).present? }),
-          'subject': get_value_for_search_param(resolve_element_from_path(@resource_found, 'subject') { |el| get_value_for_search_param(el).present? }),
-          'period': get_value_for_search_param(resolve_element_from_path(@resource_found, 'period') { |el| get_value_for_search_param(el).present? })
+          'measure': get_value_for_search_param(measure_value),
+          'subject': get_value_for_search_param(subject_value),
+          'period': get_value_for_search_param(period_value)
         }
+
         skip 'Could not find parameter value for ["measure", "subject", "period"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('MeasureReport'), search_params)

--- a/lib/modules/saner/MeasureSourcePull/publichealthmeasurestratifier_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/publichealthmeasurestratifier_sequence.rb
@@ -19,19 +19,19 @@ module Inferno
         case property
 
         when 'url'
-          values_found = resolve_path(resource, 'url')
+          values_found = resolve_path_comma_delimited(resource, 'url')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "url in Measure/#{resource.id} (#{values_found}) does not match url requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'topic.coding.code')
+          values_found = resolve_path_comma_delimited(resource, 'topic.coding.code,group.code.coding.code,group.population.code.coding.code,group.stratifier.code.coding.code,group.stratifier.component.code.coding.code,supplementalData.code.coding.code')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "code in Measure/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'definition-text'
-          values_found = resolve_path(resource, 'title')
+          values_found = resolve_path_comma_delimited(resource, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "definition-text in Measure/#{resource.id} (#{values_found}) does not match definition-text requested (#{value})"
@@ -73,9 +73,11 @@ module Inferno
           versions :r4
         end
 
+        url_value = resolve_element_from_paths_comma_delimited(@resource_found, 'url') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'url': get_value_for_search_param(resolve_element_from_path(@resource_found, 'url') { |el| get_value_for_search_param(el).present? })
+          'url': get_value_for_search_param(url_value)
         }
+
         skip 'Could not find parameter value for ["url"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -103,9 +105,11 @@ module Inferno
           versions :r4
         end
 
+        code_value = resolve_element_from_paths_comma_delimited(@resource_found, 'topic,group.code,group.population.code,group.stratifier.code,group.stratifier.component.code,supplementalData.code') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'code': get_value_for_search_param(resolve_element_from_path(@resource_found, 'topic') { |el| get_value_for_search_param(el).present? })
+          'code': get_value_for_search_param(code_value)
         }
+
         skip 'Could not find parameter value for ["code"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)
@@ -133,9 +137,11 @@ module Inferno
           versions :r4
         end
 
+        definition_text_value = resolve_element_from_paths_comma_delimited(@resource_found, 'title,subtitle,publisher,description,purpose,usage,riskAdjustment,rateAggregation,clinicalRecommendationStatement,definition,guideance') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'definition-text': get_value_for_search_param(resolve_element_from_path(@resource_found, 'title') { |el| get_value_for_search_param(el).present? })
+          'definition-text': get_value_for_search_param(definition_text_value)
         }
+
         skip 'Could not find parameter value for ["definition-text"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Measure'), search_params)

--- a/lib/modules/saner/MeasureSourcePull/saner_resource_location_sequence.rb
+++ b/lib/modules/saner/MeasureSourcePull/saner_resource_location_sequence.rb
@@ -19,30 +19,30 @@ module Inferno
         case property
 
         when '_id'
-          values_found = resolve_path(resource, 'id')
+          values_found = resolve_path_comma_delimited(resource, 'id')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "_id in Location/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when '_lastUpdated'
-          values_found = resolve_path(resource, 'meta.lastUpdated')
+          values_found = resolve_path_comma_delimited(resource, 'meta.lastUpdated')
           match_found = values_found.any? { |date| validate_date_search(value, date) }
           assert match_found, "_lastUpdated in Location/#{resource.id} (#{values_found}) does not match _lastUpdated requested (#{value})"
 
         when 'name'
-          values_found = resolve_path(resource, 'name')
+          values_found = resolve_path_comma_delimited(resource, 'name,alias')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier.value')
+          values_found = resolve_path_comma_delimited(resource, 'identifier.value')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "identifier in Location/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'address'
-          values_found = resolve_path(resource, 'address')
+          values_found = resolve_path_comma_delimited(resource, 'address')
           match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
@@ -53,31 +53,31 @@ module Inferno
           assert match_found, "address in Location/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         when 'address-city'
-          values_found = resolve_path(resource, 'address.city')
+          values_found = resolve_path_comma_delimited(resource, 'address.city')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-country'
-          values_found = resolve_path(resource, 'address.country')
+          values_found = resolve_path_comma_delimited(resource, 'address.country')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-country in Location/#{resource.id} (#{values_found}) does not match address-country requested (#{value})"
 
         when 'address-postalcode'
-          values_found = resolve_path(resource, 'address.postalCode')
+          values_found = resolve_path_comma_delimited(resource, 'address.postalCode')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
 
         when 'address-state'
-          values_found = resolve_path(resource, 'address.state')
+          values_found = resolve_path_comma_delimited(resource, 'address.state')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-use'
-          values_found = resolve_path(resource, 'address.use')
+          values_found = resolve_path_comma_delimited(resource, 'address.use')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
           assert match_found, "address-use in Location/#{resource.id} (#{values_found}) does not match address-use requested (#{value})"
@@ -118,9 +118,11 @@ module Inferno
           versions :r4
         end
 
+        _id_value = resolve_element_from_paths_comma_delimited(@resource_found, 'id') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          '_id': get_value_for_search_param(resolve_element_from_path(@resource_found, 'id') { |el| get_value_for_search_param(el).present? })
+          '_id': get_value_for_search_param(_id_value)
         }
+
         skip 'Could not find parameter value for ["_id"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -147,9 +149,11 @@ module Inferno
           versions :r4
         end
 
+        _lastUpdated_value = resolve_element_from_paths_comma_delimited(@resource_found, 'meta.lastUpdated') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          '_lastUpdated': get_value_for_search_param(resolve_element_from_path(@resource_found, 'meta.lastUpdated') { |el| get_value_for_search_param(el).present? })
+          '_lastUpdated': get_value_for_search_param(_lastUpdated_value)
         }
+
         skip 'Could not find parameter value for ["_lastUpdated"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -176,9 +180,11 @@ module Inferno
           versions :r4
         end
 
+        name_value = resolve_element_from_paths_comma_delimited(@resource_found, 'name,alias') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'name': get_value_for_search_param(resolve_element_from_path(@resource_found, 'name') { |el| get_value_for_search_param(el).present? })
+          'name': get_value_for_search_param(name_value)
         }
+
         skip 'Could not find parameter value for ["name"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -205,9 +211,11 @@ module Inferno
           versions :r4
         end
 
+        identifier_value = resolve_element_from_paths_comma_delimited(@resource_found, 'identifier') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'identifier': get_value_for_search_param(resolve_element_from_path(@resource_found, 'identifier') { |el| get_value_for_search_param(el).present? })
+          'identifier': get_value_for_search_param(identifier_value)
         }
+
         skip 'Could not find parameter value for ["identifier"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -234,9 +242,11 @@ module Inferno
           versions :r4
         end
 
+        address_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address') { |el| get_value_for_search_param(el).present? })
+          'address': get_value_for_search_param(address_value)
         }
+
         skip 'Could not find parameter value for ["address"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -263,9 +273,11 @@ module Inferno
           versions :r4
         end
 
+        address_city_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.city') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-city': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.city') { |el| get_value_for_search_param(el).present? })
+          'address-city': get_value_for_search_param(address_city_value)
         }
+
         skip 'Could not find parameter value for ["address-city"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -292,9 +304,11 @@ module Inferno
           versions :r4
         end
 
+        address_country_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.country') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-country': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.country') { |el| get_value_for_search_param(el).present? })
+          'address-country': get_value_for_search_param(address_country_value)
         }
+
         skip 'Could not find parameter value for ["address-country"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -321,9 +335,11 @@ module Inferno
           versions :r4
         end
 
+        address_postalcode_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.postalCode') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-postalcode': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.postalCode') { |el| get_value_for_search_param(el).present? })
+          'address-postalcode': get_value_for_search_param(address_postalcode_value)
         }
+
         skip 'Could not find parameter value for ["address-postalcode"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -350,9 +366,11 @@ module Inferno
           versions :r4
         end
 
+        address_state_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.state') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-state': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.state') { |el| get_value_for_search_param(el).present? })
+          'address-state': get_value_for_search_param(address_state_value)
         }
+
         skip 'Could not find parameter value for ["address-state"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)
@@ -379,9 +397,11 @@ module Inferno
           versions :r4
         end
 
+        address_use_value = resolve_element_from_paths_comma_delimited(@resource_found, 'address.use') { |el| get_value_for_search_param(el).present? }
         search_params = {
-          'address-use': get_value_for_search_param(resolve_element_from_path(@resource_found, 'address.use') { |el| get_value_for_search_param(el).present? })
+          'address-use': get_value_for_search_param(address_use_value)
         }
+
         skip 'Could not find parameter value for ["address-use"] to search by.' if search_params.any? { |_param, value| value.nil? }
 
         reply = get_resource_by_params(versioned_resource_class('Location'), search_params)


### PR DESCRIPTION
This makes it so the saner generator will use the multiple expressions in search parameters to do seraching/validation

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
